### PR TITLE
Add note about third party packages

### DIFF
--- a/src/input-validation/sanitization.md
+++ b/src/input-validation/sanitization.md
@@ -91,7 +91,7 @@ func main() {
 
 **NOTE**: Keep in mind that `ServeMux` [doesn't change][2] the URL request path for `CONNECT` requests, thus possibly making an application [vulnerable for path traversal attacks][3] if allowed request methods are not limited.
 
-Third-party packages:
+The following third-party packages are alternatives to the native HTTP request multiplexer, providing additional features. Always choose well tested and actively maintained packages.
 
 * [Gorilla Toolkit - MUX][1]
 

--- a/src/input-validation/sanitization.md
+++ b/src/input-validation/sanitization.md
@@ -89,9 +89,13 @@ func main() {
 }
 ```
 
-**NOTE**: Keep in mind that `ServeMux` [doesn't change][2] the URL request path for `CONNECT` requests, thus possibly making an application [vulnerable for path traversal attacks][3] if allowed request methods are not limited.
+**NOTE**: Keep in mind that `ServeMux` [doesn't change][2] the URL request path
+for `CONNECT` requests, thus possibly making an application [vulnerable for path
+traversal attacks][3] if allowed request methods are not limited.
 
-The following third-party packages are alternatives to the native HTTP request multiplexer, providing additional features. Always choose well tested and actively maintained packages.
+The following third-party packages are alternatives to the native HTTP request
+multiplexer, providing additional features. Always choose well tested and
+actively maintained packages.
 
 * [Gorilla Toolkit - MUX][1]
 


### PR DESCRIPTION
Fixes #59

Adds some context around third party packages. It does not explicitly endorse any packages, however it encourages the user to look into them to perhaps make a more secure decision about how the package may not have the same security problems as the native `ServeMux`