### PR TITLE
Fix lint errors found by stylecheck

### DIFF
--- a/src/access-control/URL.go
+++ b/src/access-control/URL.go
@@ -53,7 +53,7 @@ func setToken(res http.ResponseWriter, req *http.Request) {
 	//Domain
 	cookie := http.Cookie{Name: "Auth", Value: signedToken, Expires: expireCookie, HttpOnly: true, Path: "/", Domain: "127.0.0.1", Secure: true}
 	http.SetCookie(res, &cookie)
-	http.Redirect(res, req, "/profile", 307)
+	http.Redirect(res, req, "/profile", http.StatusTemporaryRedirect)
 }
 
 // middleware to protect private pages

--- a/src/access-control/URL.go
+++ b/src/access-control/URL.go
@@ -69,7 +69,7 @@ func validate(page http.HandlerFunc) http.HandlerFunc {
 
 		token, err := jwt.ParseWithClaims(cookie.Value, &Claims{}, func(token *jwt.Token) (interface{}, error) {
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-				return nil, fmt.Errorf("Unexpected signing method")
+				return nil, fmt.Errorf("unexpected signing method")
 			}
 			return []byte("secret"), nil
 		})

--- a/src/session-management/session.go
+++ b/src/session-management/session.go
@@ -51,7 +51,7 @@ func setToken(res http.ResponseWriter, req *http.Request) {
 	}
 
 	http.SetCookie(res, &cookie)
-	http.Redirect(res, req, "/profile", 307)
+	http.Redirect(res, req, "/profile", http.StatusTemporaryRedirect)
 }
 
 // middleware to protect private pages

--- a/src/session-management/session.go
+++ b/src/session-management/session.go
@@ -68,7 +68,7 @@ func validate(page http.HandlerFunc) http.HandlerFunc {
 		token, err := jwt.ParseWithClaims(cookie.Value, &Claims{},
 			func(token *jwt.Token) (interface{}, error) {
 				if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-					return nil, fmt.Errorf("Unexpected signing method")
+					return nil, fmt.Errorf("unexpected signing method")
 				}
 				return []byte("secret"), nil
 			},


### PR DESCRIPTION
I appreciate this repository, I am learning secure coding with Go by this repository.
BTW, I fixed some lint errors. I would appreciate it if you could check this PR.

```bash
$ golangci-lint run --disable-all --enable stylecheck
src/access-control/URL.go:72:27: ST1005: error strings should not be capitalized (stylecheck)
                                return nil, fmt.Errorf("Unexpected signing method")
                                                      ^
src/session-management/session.go:71:28: ST1005: error strings should not be capitalized (stylecheck)
                                        return nil, fmt.Errorf("Unexpected signing method")
                                                              ^
src/access-control/URL.go:56:38: ST1013: should use constant http.StatusTemporaryRedirect instead of numeric literal 307 (stylecheck)
        http.Redirect(res, req, "/profile", 307)
                                            ^
src/session-management/session.go:54:38: ST1013: should use constant http.StatusTemporaryRedirect instead of numeric literal 307 (stylecheck)
        http.Redirect(res, req, "/profile", 307)
                                            ^
```

Regards,