### PR TITLE
Decouple encryption, decryption and secret ops

### DIFF
--- a/src/cryptographic-practices/README.md
+++ b/src/cryptographic-practices/README.md
@@ -192,8 +192,8 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"fmt"
 	"io"
+	"log"
 )
 
 func encrypt(val []byte, secret []byte) ([]byte, error) {
@@ -252,23 +252,23 @@ func secret() ([]byte, error) {
 func main() {
 	secret, err := secret()
 	if err != nil {
-		panic(fmt.Sprintf("unable to create secret key: %v", err))
+		log.Fatalf("unable to create secret key: %v", err)
 	}
 
 	message := []byte("Welcome to Go Language Secure Coding Practices")
-	fmt.Printf("Message  : %s\n", message)
+	log.Printf("Message  : %s\n", message)
 
 	encrypted, err := encrypt(message, secret)
 	if err != nil {
-		panic(fmt.Sprintf("unable to encrypt the data: %v", err))
+		log.Fatalf("unable to encrypt the data: %v", err)
 	}
-	fmt.Printf("Encrypted: %x\n", encrypted)
+	log.Printf("Encrypted: %x\n", encrypted)
 
 	decrypted, err := decrypt(encrypted, secret)
 	if err != nil {
-		panic(fmt.Sprintf("unable to decrypt the data: %v", err))
+		log.Fatalf("unable to decrypt the data: %v", err)
 	}
-	fmt.Printf("Decrypted: %s\n", decrypted)
+	log.Printf("Decrypted: %s\n", decrypted)
 }
 ```
 


### PR DESCRIPTION
RE: https://github.com/OWASP/Go-SCP/issues/68
CC: @PauloASilva 

This piece of addition helps users to create a custom package out of a simple piece of code/functionality without worrying about going through decoupling process. It provides the barebones so it's up to the user to enhance/refactor etc. while inheriting it. In addition to the decoupled approach, the `nonce` doesn't need to be passed around. It is being generated/extracted within the decoupled methods.

**Note**: The whole example is taken from [inanzzz.com](http://www.inanzzz.com/index.php/post/f3pe/data-encryption-and-decryption-with-a-secret-key-in-golang) with respect but the string casting has been removed and left to the user to handle if it is needed so the methods are less opinionated on a such minor point.