### PR TITLE
fix error CompareHashAndPassword() arguments

### DIFF
--- a/src/authentication-password-management/validation-and-storage.md
+++ b/src/authentication-password-management/validation-and-storage.md
@@ -203,7 +203,7 @@ if err := record.Scan(&expectedPassword); err != nil {
     // should continue
 }
 
-if bcrypt.CompareHashAndPassword(password, []byte(expectedPassword)) != nil {
+if bcrypt.CompareHashAndPassword([]byte(expectedPassword), password) != nil {
     // passwords do not match
 
     // passwords mismatch should be logged (see Error Handling and Logging)


### PR DESCRIPTION
Hi!

We discussed these changes in [issue](https://github.com/OWASP/Go-SCP/issues/100).

Please consider and accept the changes.

Thanks
