### PR TITLE
Minor update to AES-GCM encrypt example.

### DIFF
--- a/src/cryptographic-practices/README.md
+++ b/src/cryptographic-practices/README.md
@@ -147,7 +147,8 @@ func encrypt(val []byte, secret []byte) ([]byte, error) {
         return nil, err
     }
 
-    nonce := make([]byte, aead.NonceSize())
+    buffer := make([]byte, aead.NonceSize()+aead.Overhead()+len(val))
+	nonce := buffer[:aead.NonceSize()]
     if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
         return nil, err
     }


### PR DESCRIPTION
Updated the AES-GCM encrypt function to avoid one heap memory allocation. The internal GCM implementation uses 'sliceForAppend' that will allocate new memory if the 'dst' buffer does not have enough capacity. With this fix, the slice 'nonce' has now enough capacity to be used as 'dst' without memory re-allocation.